### PR TITLE
Update Makefile (otp 26)

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -162,7 +162,7 @@ clean-c_src:
 ifneq ($(wildcard $(C_SRC_ENV)),)
 -include $(C_SRC_ENV)
 else
-ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
-ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
-ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
+ERTS_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]), halt().")
+ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]), halt().")
+ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]), halt().")
 endif


### PR DESCRIPTION
With Erlang/OTP 26, the build fails with the error:
```
#26 204.6 make: Entering directory '/app/deps/keccakf1600/c_src'
#26 206.0 Error! Failed to eval: io:format("~s/erts-~s/include/", [code:root_dir(), erlang:system_info(version)]).
#26 206.0 
#26 207.5 Error! Failed to eval: io:format("~s", [code:lib_dir(erl_interface, include)]).
#26 207.5 
#26 207.5  C      decaf-utils.c
#26 209.1 Error! Failed to eval: io:format("~s/erts-~s/include/", [code:root_dir(), erlang:system_info(version)]).
#26 209.1 
#26 210.6 Error! Failed to eval: io:format("~s", [code:lib_dir(erl_interface, include)]).
#26 210.6 
#26 210.6  C      keccakf1600_nif.c
#26 210.6 In file included from /app/deps/keccakf1600/c_src/keccakf1600_nif.c:4:
#26 210.6 /app/deps/keccakf1600/c_src/keccakf1600_nif.h:9:10: fatal error: erl_nif.h: No such file or directory
#26 210.6     9 | #include <erl_nif.h>
#26 210.6       |          ^~~~~~~~~~~
#26 210.6 compilation terminated.
#26 210.6 make: *** [Makefile:146: /app/deps/keccakf1600/c_src/keccakf1600_nif.o] Error 1
#26 210.6 make: Leaving directory '/app/deps/keccakf1600/c_src'
```

The discussion is here: https://github.com/erlang/otp/issues/6916
